### PR TITLE
Create migration script for UAC-QID-Service

### DIFF
--- a/manual_scripts/0001-migrate-uac-qid-data.sql
+++ b/manual_scripts/0001-migrate-uac-qid-data.sql
@@ -13,4 +13,4 @@ SELECT uac, qid, unique_number from casev2.uac_qid_link;
 
 SELECT setval('uacqid.uac_qid_unique_number_seq', COALESCE((SELECT last_value FROM casev2.uac_qid_link_unique_number_seq), 1), false);
 
-DROP SCHEMA iac CASCASE ALL;
+DROP SCHEMA iac CASCADE;

--- a/manual_scripts/0001-migrate-uac-qid-data.sql
+++ b/manual_scripts/0001-migrate-uac-qid-data.sql
@@ -14,3 +14,5 @@ SELECT uac, qid, unique_number from casev2.uac_qid_link;
 SELECT setval('uacqid.uac_qid_unique_number_seq', COALESCE((SELECT last_value FROM casev2.uac_qid_link_unique_number_seq), 1), false);
 
 DROP SCHEMA iac CASCADE;
+
+UPDATE casev2.event SET event_channel = 'RM', event_source = 'CASE_SERVICE', event_transaction_id = uuid_generate_v4(), event_payload = '{}';

--- a/manual_scripts/0001-migrate-uac-qid-data.sql
+++ b/manual_scripts/0001-migrate-uac-qid-data.sql
@@ -1,0 +1,16 @@
+-- ********************************************
+-- *** MANUAL RM SQL DATABASE UPDATE SCRIPT ***
+-- ********************************************
+-- *** Number: 0001                         ***
+-- *** Purpose: Move UAC/QID pair data out  ***
+-- ***          of the Case Processor and   ***
+-- ***          into the UAC-QID-Service.   ***
+-- *** Author: Nick Grant                   ***
+-- ********************************************
+
+INSERT INTO uacqid.uac_qid (uac, qid, unique_number)
+SELECT uac, qid, unique_number from casev2.uac_qid_link;
+
+SELECT setval('uacqid.uac_qid_unique_number_seq', COALESCE((SELECT last_value FROM casev2.uac_qid_link_unique_number_seq), 1), false);
+
+DROP SCHEMA iac CASCASE ALL;


### PR DESCRIPTION
# Motivation and Context
We have deprecated the IAC Service, but we need to migrate the data out of the Case Processor and into the `uacqid` schema so that we can guarantee the uniqueness of any UACs and QIDs we generate.

# What has changed
Created migration script.

# How to test?
Set up an environment with the production images of Case Processor and IAC Service. Load an unaddressed batch. Run this script. Check that the data in `uacqid.uac_qid` matches `casev2.uac_qid_link`.

# Links
Trello: https://trello.com/c/mlM35xRH
