### PR TITLE
Amend migration 0005 to create the receipt_received column

### DIFF
--- a/manual_scripts/0005-modify-receipt-received-column.sql
+++ b/manual_scripts/0005-modify-receipt-received-column.sql
@@ -17,11 +17,5 @@ ALTER TABLE casev2.cases
 ALTER TABLE casev2.cases
     ALTER COLUMN receipt_received SET DEFAULT false;
 
-UPDATE actionv2.cases
-SET receipt_received = false
-WHERE receipt_received ISNULL;
-
 ALTER TABLE actionv2.cases
-    ALTER COLUMN receipt_received SET NOT NULL;
-ALTER TABLE actionv2.cases
-    ALTER COLUMN receipt_received SET DEFAULT false;
+    ADD COLUMN IF NOT EXISTS receipt_received BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
# Motivation and Context
The column doesn't not exist before running these migrations so this script needs to add the column rather than attempting to modify it.

# What has changed
* Amend migration 0005 to create the receipt_received column in actionv2.cases

# How to test?
Run through the migrations in an environment in the state of prod after the unaddressed print run.

# Links
https://trello.com/c/NHLG59GN/1014-bug-migration-scripts-never-create-actionv2cases-receiptreceived-column
https://trello.com/c/ArDwE6ru/930-run-book-for-sample-load-phase-1-13