### PR TITLE
Add case type column to cases tables.

### DIFF
--- a/manual_scripts/0008-add-case-type-column.sql
+++ b/manual_scripts/0008-add-case-type-column.sql
@@ -1,0 +1,28 @@
+-- ********************************************
+-- *** MANUAL RM SQL DATABASE UPDATE SCRIPT ***
+-- ********************************************
+-- *** Number: 0008                         ***
+-- *** Purpose: Create case type column     ***
+-- ***          and set to HH for existing  ***
+-- ***          cases.                      ***
+-- *** Author: R Weeks                      ***
+-- ********************************************
+
+ALTER TABLE casev2.cases
+ADD COLUMN case_type varchar(255);
+
+UPDATE casev2.cases
+SET case_type = 'HH'
+WHERE case_type is null;
+
+ALTER TABLE actionv2.cases
+ADD COLUMN case_type varchar(255);
+
+UPDATE actionv2.cases
+SET case_type = 'HH'
+WHERE case_type is null;
+
+
+
+
+


### PR DESCRIPTION
# Motivation and Context
Add new Case Type column to Case Processor and Action scheduler cases tables.  
This will allow RM to differentiate a Household case from a Household individual PQ case.

# What has changed
SQL script to add column and set existing cases to 'HH'.

# How to test?
Run script in Docker Dev.

# Links
https://trello.com/c/gUMjDkBu/1064-create-case-type-variable-to-differentiate-hh-and-hi-as-opposed-to-address-type-5