### PR TITLE
Add manual script for address_invalid column

### DIFF
--- a/manual_scripts/0009-add-invalid-address-column.sql
+++ b/manual_scripts/0009-add-invalid-address-column.sql
@@ -2,7 +2,7 @@
 -- *** MANUAL RM SQL DATABASE UPDATE SCRIPT                                 ***
 -- ****************************************************************************
 -- *** Number: 0009                                                         ***
--- *** Purpose: Add new case column 'refusal_received' in actionv2          ***
+-- *** Purpose: Add new case column 'address_invalid' in actionv2           ***
 -- ***          & casev2 schemas set to be not null and default to false    ***
 -- *** Author: Nick Grant                                                   ***
 -- ****************************************************************************

--- a/manual_scripts/0009-add-invalid-address-column.sql
+++ b/manual_scripts/0009-add-invalid-address-column.sql
@@ -1,0 +1,14 @@
+-- ****************************************************************************
+-- *** MANUAL RM SQL DATABASE UPDATE SCRIPT                                 ***
+-- ****************************************************************************
+-- *** Number: 0009                                                         ***
+-- *** Purpose: Add new case column 'refusal_received' in actionv2          ***
+-- ***          & casev2 schemas set to be not null and default to false    ***
+-- *** Author: Nick Grant                                                   ***
+-- ****************************************************************************
+
+ALTER TABLE casev2.cases
+    ADD COLUMN IF NOT EXISTS address_invalid BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE actionv2.cases
+    ADD COLUMN IF NOT EXISTS address_invalid BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
# Motivation and Context
Fieldwork might discover that an address is not valid and notify RM via a message. We need to handle that message so that we cease doing follow-up actions and we know why we haven't had a response.

# What has changed
New DB column.

# How to test?
Run the script in an existing DB.

# Links
Trello: https://trello.com/c/bKxycLe3