### PR TITLE
Add script to add undelivered_as_addressed column to case tables

### DIFF
--- a/manual_scripts/0010-add-undelivered-as-addressed-column.sql
+++ b/manual_scripts/0010-add-undelivered-as-addressed-column.sql
@@ -1,0 +1,14 @@
+-- ****************************************************************************
+-- *** MANUAL RM SQL DATABASE UPDATE SCRIPT                                 ***
+-- ****************************************************************************
+-- *** Number: 0010                                                         ***
+-- *** Purpose: Add new case column 'undelivered_as_addressed' in actionv2  ***
+-- ***          & casev2 schemas set to be not null and default to false    ***
+-- *** Author: Nick Grant                                                   ***
+-- ****************************************************************************
+
+ALTER TABLE casev2.cases
+    ADD COLUMN IF NOT EXISTS undelivered_as_addressed BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE actionv2.cases
+    ADD COLUMN IF NOT EXISTS undelivered_as_addressed BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
# Motivation and Context
QM (Leidos) and PPO (Royal Mail) will receive email that is undeliverable - undelivered as addressed - and they will notify RM. We need to send a message to Field so that the cases can be followed up and we can find out why the mail couldn't be delivered.

# What has changed
Added undelivered_as_addressed column to case tables

# How to test?
Run the acceptance tests, along with Action Scheduler, Case API, Pubsub and Case Processor on the same branch (`undelivered-as-addressed`) along with census-rm-docker-dev.

# Links
Trello: https://trello.com/c/HOWUDNMR