### PR TITLE
DDL script to create rm developer group role

### DIFF
--- a/manual_scripts/schema_and_data_migration/0012-add-rm-dev-group-role.sql
+++ b/manual_scripts/schema_and_data_migration/0012-add-rm-dev-group-role.sql
@@ -1,0 +1,28 @@
+-- ********************************************
+-- *** MANUAL RM SQL DATABASE UPDATE SCRIPT ***
+-- ********************************************
+-- *** Number: 0012                         ***
+-- *** Purpose: Create and grant            *** 
+-- *** permissions on rm dev group role     ***
+-- ***                                      ***
+-- *** Author: Adam Hawtin                  ***
+-- ********************************************
+
+CREATE ROLE rm_developer;
+
+GRANT CONNECT ON DATABASE rm TO rm_developer;
+
+GRANT USAGE ON SCHEMA casev2 TO rm_developer;
+GRANT USAGE ON SCHEMA actionv2 TO rm_developer;
+GRANT USAGE ON SCHEMA uacqid TO rm_developer;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA casev2 TO rm_developer;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA casev2 TO rm_developer;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA actionv2 TO rm_developer;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA actionv2 TO rm_developer;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA uacqid TO rm_developer;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA uacqid TO rm_developer;
+GRANT ALL PRIVILEGES ON DATABASE rm TO rm_developer;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA casev2 GRANT ALL PRIVILEGES ON TABLES TO rm_developer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA actionv2 GRANT ALL PRIVILEGES ON TABLES TO rm_developer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA uacqid GRANT ALL PRIVILEGES ON TABLES TO rm_developer;


### PR DESCRIPTION
# Motivation and Context
We need a group role for RM developer database access

# What has Changed
* Add DDL script to create rm developer group role

# How to test?
Run the new DDL script in your environment, create a user and grant them the new rm_developer group role with `GRANT rm_developer TO <user>;`. Connect as this user and you should be able to perform all the operations we might need to for ops support.

# Links
https://trello.com/c/Ey6fluwI/1228-create-ddl-to-add-rmdev-group-role-with-required-permissions-so-dev-db-accounts-can-be-created-given-appropriate-access