### PR TITLE
Add case ID unique constraint

### DIFF
--- a/manual_scripts/schema_and_data_migration/0013-add-unique-constraint-case-id.sql
+++ b/manual_scripts/schema_and_data_migration/0013-add-unique-constraint-case-id.sql
@@ -10,6 +10,10 @@
 -- *** Author: Liam Toozer                  ***
 -- ********************************************
 
+-- Drop our existing (non-unique) constraints & indexes first
+ALTER TABLE actionv2.cases DROP CONSTRAINT IF EXISTS case_id_idx;
+DROP INDEX IF EXISTS casev2.case_id_idx;
+
 ALTER TABLE actionv2.cases
     ADD CONSTRAINT case_id UNIQUE (case_id);
 

--- a/manual_scripts/schema_and_data_migration/0013-add-unique-constraint-case-id.sql
+++ b/manual_scripts/schema_and_data_migration/0013-add-unique-constraint-case-id.sql
@@ -1,0 +1,17 @@
+-- ********************************************
+-- *** MANUAL RM SQL DATABASE UPDATE SCRIPT ***
+-- ********************************************
+-- *** Number: 0013                         ***
+-- *** Purpose: Create unique constraint    ***
+-- *** on case_id. NOTE: This will also     ***
+-- *** create a unique index with the same  ***
+-- *** name                                 ***
+-- ***                                      ***
+-- *** Author: Liam Toozer                  ***
+-- ********************************************
+
+ALTER TABLE actionv2.cases
+    ADD CONSTRAINT case_id UNIQUE (case_id);
+
+ALTER TABLE casev2.cases
+    ADD CONSTRAINT case_id UNIQUE (case_id);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Case IDs need to be unique in our case tables so that we can throw an error if we receive duplicate messages (e.g. from a CCS request message).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Remove unique constraint (which removes the associated index) on `action.cases` table
* Remove existing, non-unique index on `casev2.cases` table.
* Alter `actionv2.cases` and `casev2.cases` tables to add a unique constraint.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the SQL against your DB. Publish CCS message (see acceptance tests for an example msg) with the same case ID more than once. The case-processor should correctly log that the case ID unique constraint is violated.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/UfX9Ibig/1270-add-a-unique-constraint-to-the-caseid-column-in-casev2cases-table-3

# Screenshots (if appropriate):