### PR TITLE
Update trigger date on previously created WoC action rules

### DIFF
--- a/manual_scripts/action_plans_and_rules/0004-woc-update-trigger-dates-for-reminder-letters.sql
+++ b/manual_scripts/action_plans_and_rules/0004-woc-update-trigger-dates-for-reminder-letters.sql
@@ -1,0 +1,15 @@
+-- *********************************************
+-- *** MANUAL RM SQL DATABASE ACTION RULES   ***
+-- *** SCRIPT                                ***
+-- *********************************************
+-- *** Number: 0004                          ***
+-- *** Purpose: Update incorrect trigger     ***
+-- *** dates for woc reminders               ***
+-- *** Author: G Edwards                     ***
+-- *********************************************
+
+
+UPDATE actionv2.action_rule
+SET trigger_date_time = '2019-10-28 06:00:00.0000'
+WHERE action_plan_id='432f0597-0076-4adb-834b-bf249dc06ded'
+AND action_type  in ('P_QU_H1', 'P_QU_H2','P_QU_H4');


### PR DESCRIPTION
# Motivation and Context
The date on 3 previously created action rules was incorrect.  This is to update them to the correct dates.

# What has changed
New script to update the trigger dates for 3 action rules that have already been created.  Note - 28th Oct is GMT so the 6:00am UTC start time in the script is correct.

Trello card: https://trello.com/c/HO6Lf1cB