### PR TITLE
change case table primary key and alter this on event and uac_qid_link

### DIFF
--- a/manual_scripts/schema_and_data_migration/0013-case-ref-fpe-change.sql
+++ b/manual_scripts/schema_and_data_migration/0013-case-ref-fpe-change.sql
@@ -1,0 +1,12 @@
+// change cases primary key
+ALTER TABLE casev2.cases DROP CONSTRAINT cases_pkey;
+ALTER TABLE casev2.cases ADD PRIMARY KEY (id);
+ALTER TABLE casev2.cases ADD secret_sequence_number SERIAL NOT NULL;
+
+// change case key
+ALTER TABLE casesv2.event DROP COLUMN caze_case_ref;
+ALTER TABLE casesv2.event ADD COLUMN caze_case_id UUID;
+
+// change case key
+ALTER TABLE casesv2.uac_qid_link DROP COLUMN caze_case_ref;
+ALTER TABLE casesv2.uac_qid_link ADD COLUMN caze_case_id UUID;


### PR DESCRIPTION
# Motivation and Context
for the new format preserving encryption columns on case schema

# What has changed
changes primary key on cases table and references to it on uac_qid_link & event

# How to test?
With master docker-dev 'make up'
Then clone and build this case-api: https://github.com/ONSdigital/census-rm-case-api/tree/model-changes-for-fpe-case-ref
Then clone and build this https://github.com/ONSdigital/census-rm-case-processor/tree/pseudorandom_case_ref_for_2021

Then 'make up' again in docker-dev

if you docker logs -f caseprocessor &   docker logs -f caseapi they should show database issues and fail to start.

Now apply the new scripts.

Then watch in wonder as caseprocessor and caseapi start working






# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):