### PR TITLE
Remove ccs_case column and add survey column

### DIFF
--- a/groundzero_ddl/actionv2.sql
+++ b/groundzero_ddl/actionv2.sql
@@ -52,6 +52,7 @@ CREATE TABLE actionv2.cases (
     refusal_received boolean NOT NULL DEFAULT FALSE,
     region varchar(255),
     state varchar(255),
+    survey varchar(255) NOT NULL,
     town_name varchar(255),
     treatment_code varchar(255),
     undelivered_as_addressed boolean NOT NULL DEFAULT FALSE,

--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -39,8 +39,8 @@ CREATE TABLE casev2.cases (
     case_type varchar(255),
     address_invalid boolean NOT NULL DEFAULT FALSE,
     undelivered_as_addressed boolean NOT NULL DEFAULT FALSE,
-    ccs_case boolean NOT NULL DEFAULT FALSE,
     secret_sequence_number SERIAL NOT NULL,
+    survey varchar(255) NOT NULL,
     CONSTRAINT cases_pkey PRIMARY KEY (case_id)
 );
 


### PR DESCRIPTION
# Motivation and Context
As part of CCS refactoring, the `ccs_case` column has been removed and a more generic `survey` column has been added.  Note - the `ccs_case` column is still required in the uac_qid_link table.

# Links
https://trello.com/c/4gq2Ufvz