### PR TITLE
Remove survey column from actionv2 ground zero script

### DIFF
--- a/groundzero_ddl/actionv2.sql
+++ b/groundzero_ddl/actionv2.sql
@@ -52,7 +52,6 @@ CREATE TABLE actionv2.cases (
     refusal_received boolean NOT NULL DEFAULT FALSE,
     region varchar(255),
     state varchar(255),
-    survey varchar(255) NOT NULL,
     town_name varchar(255),
     treatment_code varchar(255),
     undelivered_as_addressed boolean NOT NULL DEFAULT FALSE,


### PR DESCRIPTION
# Motivation and Context
Survey column shouldn't exist in the actionv2.cases table as it isn't in the model in action processor.  It was added by mistake.

# What has changed
Removed the survey column from actioinv2.cases.

# How to test?
Run the ground zero script then check that the acceptance tests pass.
