### PR TITLE
Remove case state

### DIFF
--- a/groundzero_ddl/actionv2.sql
+++ b/groundzero_ddl/actionv2.sql
@@ -51,7 +51,6 @@ CREATE TABLE actionv2.cases (
     receipt_received boolean NOT NULL DEFAULT FALSE,
     refusal_received boolean NOT NULL DEFAULT FALSE,
     region varchar(255),
-    state varchar(255),
     town_name varchar(255),
     treatment_code varchar(255),
     undelivered_as_addressed boolean NOT NULL DEFAULT FALSE,

--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -32,7 +32,6 @@ CREATE TABLE casev2.cases (
     postcode varchar(255),
     receipt_received boolean NOT NULL DEFAULT FALSE,
     region varchar(255),
-    state varchar(255),
     town_name varchar(255),
     treatment_code varchar(255),
     uprn varchar(255),

--- a/patches/300_drop_column_state_from_cases.sql
+++ b/patches/300_drop_column_state_from_cases.sql
@@ -1,0 +1,5 @@
+ALTER table actionv2.cases
+DROP COLUMN state;
+
+ALTER TABLE casev2.cases
+DROP COLUMN state;


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can now safely remove the redundant case `state` column from our schemas

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added patch and updated ground zero

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Make sure tests and acceptance tests still pass from the links below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/dBJe87ZS/481-get-rid-of-casestate-from-case-table-8

https://github.com/ONSdigital/census-rm-case-processor/pull/101
https://github.com/ONSdigital/census-rm-case-api/pull/53
https://github.com/ONSdigital/census-rm-action-scheduler/pull/64
https://github.com/ONSdigital/census-rm-action-worker/pull/9
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/169