### PR TITLE
fixed rebuild_from_groundzero script

### DIFF
--- a/groundzero_ddl/rebuild_from_ground_zero.sh
+++ b/groundzero_ddl/rebuild_from_ground_zero.sh
@@ -1,4 +1,4 @@
-cd /groundzero_ddl/
+cd groundzero_ddl
 
 PSQL_CONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/root/.postgresql/postgresql.key hostaddr=$DB_HOST user=rmuser password=password dbname=$DB_NAME"
 psql "$PSQL_CONNECT_WRITE_MODE" -f destroy_schemas.sql


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The location of the groundzero script was wrong and broke in the pipeline.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Fixed groundzero location

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Create a ddl pod in your GCP environment with this pr. 
- You can test this by creating a pod in your environment and trying to run `kubectl exec census-rm-ddl -- /bin/bash groundzero_ddl/rebuild_from_ground_zero.sh`. Should destroy the schemas and rebuild them.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):