### PR TITLE
RMC-317: Add hand delivery on outbound msgs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@
 <!--- What tests have been written -->
 
 # Checklist
+Reminder: Make sure to version tag this after the PR is merged
 * [ ] Updated patch number
 * [ ] Updated version_tag
 

--- a/groundzero_ddl/actionv2.sql
+++ b/groundzero_ddl/actionv2.sql
@@ -55,6 +55,7 @@ CREATE TABLE actionv2.cases (
     treatment_code varchar(255),
     undelivered_as_addressed boolean NOT NULL DEFAULT FALSE,
     uprn varchar(255),
+    hand_delivery boolean NOT NULL DEFAULT FALSE,
     CONSTRAINT cases_pkey PRIMARY KEY (case_ref),
     CONSTRAINT case_id UNIQUE (case_id)
 );

--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -41,7 +41,7 @@ CREATE TABLE casev2.cases (
     undelivered_as_addressed boolean NOT NULL DEFAULT FALSE,
     secret_sequence_number SERIAL NOT NULL,
     survey varchar(255) NOT NULL,
-    hand_delivery boolean NOT NULL DEFAULT FALSE
+    hand_delivery boolean NOT NULL DEFAULT FALSE,
     CONSTRAINT cases_pkey PRIMARY KEY (case_id)
 );
 

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -5,5 +5,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (700, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.5.0', current_timestamp);

--- a/patches/700_add_new_hand_delivery_column_to_action_schema.sql
+++ b/patches/700_add_new_hand_delivery_column_to_action_schema.sql
@@ -1,0 +1,2 @@
+ALTER TABLE actionv2.cases
+    ADD COLUMN IF NOT EXISTS hand_delivery boolean NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to add `handDeliver` bool flag on each of our outgoing Action Instruction `CREATE` messages to Field. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Updated actionv2.cases to hold the flag
* Added comma casev2.cases in ground zero 

# Checklist
* [x] Updated patch number
* [x] Updated version_tag

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the scheme

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/774V6fGU/580-add-handdelivery-flag-to-casecreated-and-caseupdated-events-and-case-api-8

https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/30
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/191
https://github.com/ONSdigital/census-rm-action-worker/pull/10
https://github.com/ONSdigital/census-rm-case-processor/pull/112
https://github.com/ONSdigital/census-rm-action-scheduler/pull/65