### PR TITLE
Add created and updated timestamps to uacqidlink table

### DIFF
--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -67,6 +67,8 @@
         batch_id uuid,
         blank_questionnaire BOOLEAN DEFAULT false not null,
         ccs_case BOOLEAN DEFAULT false not null,
+        created_date_time timestamp with time zone,
+        last_updated timestamp with time zone,
         qid varchar(255),
         uac varchar(255),
         caze_case_id uuid,

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1300, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.12.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1400, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v2.1.0', current_timestamp);

--- a/patches/1400_add_timestamps_to_uacqidlink.sql
+++ b/patches/1400_add_timestamps_to_uacqidlink.sql
@@ -5,11 +5,9 @@ ALTER TABLE casev2.uac_qid_link
     ADD COLUMN IF NOT EXISTS created_date_time timestamp with time zone;
 
 UPDATE casev2.uac_qid_link
-SET (last_updated)
-VALUES (now())
+SET last_updated = now()
 WHERE last_updated IS NULL;
 
 UPDATE casev2.uac_qid_link
-SET (created_date_time)
-VALUES (now())
+SET created_date_time = now()
 WHERE last_updated IS NULL;

--- a/patches/1400_add_timestamps_to_uacqidlink.sql
+++ b/patches/1400_add_timestamps_to_uacqidlink.sql
@@ -1,0 +1,15 @@
+ALTER TABLE casev2.uac_qid_link
+    ADD COLUMN IF NOT EXISTS last_updated timestamp with time zone;
+
+ALTER TABLE casev2.uac_qid_link
+    ADD COLUMN IF NOT EXISTS created_date_time timestamp with time zone;
+
+UPDATE casev2.uac_qid_link
+SET (last_updated)
+VALUES (now())
+WHERE last_updated IS NULL;
+
+UPDATE casev2.uac_qid_link
+SET (created_date_time)
+VALUES (now())
+WHERE last_updated IS NULL;

--- a/patches/1400_add_timestamps_to_uacqidlink.sql
+++ b/patches/1400_add_timestamps_to_uacqidlink.sql
@@ -5,9 +5,9 @@ ALTER TABLE casev2.uac_qid_link
     ADD COLUMN IF NOT EXISTS created_date_time timestamp with time zone;
 
 UPDATE casev2.uac_qid_link
-SET last_updated = now()
+SET last_updated = current_timestamp
 WHERE last_updated IS NULL;
 
 UPDATE casev2.uac_qid_link
-SET created_date_time = now()
+SET created_date_time = current_timestamp
 WHERE last_updated IS NULL;


### PR DESCRIPTION
# Motivation and Context
We needed created & updated timestamps on the UAC QID Link table, so that we can send any updated rows to DAP via the data export process, which only sends daily deltas.

# What has changed
Added new columns for created & updated to UacQidLink table.

# How to test?
Run an acceptance test which updates a UAC QID link and make sure the updated timestamp is correctly updated, and the created timestamp remains unchanged.

# Links
Trello: https://trello.com/c/91vLJAO8