### PR TITLE
Add missing indexes to improve performance

### DIFF
--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -78,7 +78,10 @@ create index cases_case_ref_idx on cases (case_ref);
 create index lsoa_idx on cases (lsoa);
 create index event_type_idx on event (event_type);
 create index rm_event_processed_idx on event (rm_event_processed);
+create index event_uac_qid_link_id on event (uac_qid_link_id);
+create index event_caze_case_id on event (caze_case_id);
 create index qid_idx on uac_qid_link (qid);
+create index uac_qid_caze_case_id on uac_qid_link (caze_case_id);
 
     alter table if exists event 
        add constraint FKkrvohvnibf3k12ljhgiqrqicj 

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1500, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v2.2.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v2.3.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v2.2.0'
+current_version = 'v2.3.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/1600_add_extra_case_event_and_uacqid_indexes.sql
+++ b/patches/1600_add_extra_case_event_and_uacqid_indexes.sql
@@ -1,3 +1,3 @@
-create index IF NOT EXISTS casev2.event_uac_qid_link_id on event (uac_qid_link_id);
-create index IF NOT EXISTS casev2.event_caze_case_id on event (caze_case_id);
-create index IF NOT EXISTS casev2.uac_qid_caze_case_id on uac_qid_link (caze_case_id);
+create index IF NOT EXISTS event_uac_qid_link_id on casev2.event (uac_qid_link_id);
+create index IF NOT EXISTS event_caze_case_id on casev2.event (caze_case_id);
+create index IF NOT EXISTS uac_qid_caze_case_id on casev2.uac_qid_link (caze_case_id);

--- a/patches/1600_add_extra_case_event_and_uacqid_indexes.sql
+++ b/patches/1600_add_extra_case_event_and_uacqid_indexes.sql
@@ -1,3 +1,3 @@
-create index IF NOT EXISTS event_uac_qid_link_id on event (uac_qid_link_id);
-create index IF NOT EXISTS event_caze_case_id on event (caze_case_id);
-create index IF NOT EXISTS uac_qid_caze_case_id on uac_qid_link (caze_case_id);
+create index IF NOT EXISTS casev2.event_uac_qid_link_id on event (uac_qid_link_id);
+create index IF NOT EXISTS casev2.event_caze_case_id on event (caze_case_id);
+create index IF NOT EXISTS casev2.uac_qid_caze_case_id on uac_qid_link (caze_case_id);

--- a/patches/1600_add_extra_case_event_and_uacqid_indexes.sql
+++ b/patches/1600_add_extra_case_event_and_uacqid_indexes.sql
@@ -1,0 +1,3 @@
+create index IF NOT EXISTS event_uac_qid_link_id on event (uac_qid_link_id);
+create index IF NOT EXISTS event_caze_case_id on event (caze_case_id);
+create index IF NOT EXISTS uac_qid_caze_case_id on uac_qid_link (caze_case_id);


### PR DESCRIPTION
# Motivation and Context
Case API was performing very badly when retrieving case events.

# What has changed
Added indexes to both `uac_qid_link` and `event` table to prevent table-scanning.

# How to test?
Load large sample. Call case API including `?caseEvents=true`. It should be fast response time.

# Links
Trello: https://trello.com/c/fHPtdl59