### PR TITLE
Persist quarantined messages

### DIFF
--- a/build_groundzero_ddl.sh
+++ b/build_groundzero_ddl.sh
@@ -2,6 +2,7 @@
 rm groundzero_ddl/actionv2.sql
 rm groundzero_ddl/casev2.sql
 rm groundzero_ddl/uacqid.sql
+rm groundzero_ddl/exceptionmanager.sql
 rm -rf git_cloned_src
 rm -rf temp_clone
 
@@ -29,6 +30,13 @@ else
   git clone --branch $UAC_QID_SERVICE_BRANCH git@github.com:ONSdigital/census-rm-uac-qid-service.git
 fi
 
+if [ -z "$EXCEPTION_MANAGER_BRANCH" ]; then
+  git clone git@github.com:ONSdigital/census-rm-exception-manager.git
+else
+  echo "Cloning UAC QID Service branch $EXCEPTION_MANAGER_BRANCH"
+  git clone --branch $EXCEPTION_MANAGER_BRANCH git@github.com:ONSdigital/census-rm-exception-manager.git
+fi
+
 cd ..
 
 mkdir -p git_cloned_src/uk/gov/ons/census/casesvc/model/entity
@@ -42,6 +50,9 @@ cp temp_clone/census-rm-action-scheduler/src/main/java/uk/gov/ons/census/action/
 mkdir -p git_cloned_src/uk/gov/ons/census/uacqid/model/entity
 cp temp_clone/census-rm-uac-qid-service/src/main/java/uk/gov/ons/census/uacqid/model/entity/*.java git_cloned_src/uk/gov/ons/census/uacqid/model/entity
 
+mkdir -p git_cloned_src/uk/gov/ons/census/exceptionmanager/model/entity
+cp temp_clone/census-rm-exception-manager/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/*.java git_cloned_src/uk/gov/ons/census/exceptionmanager/model/entity
+
 rm -rf temp_clone
 
 mvn clean package
@@ -51,3 +62,4 @@ rm -rf git_cloned_src
 java -jar target/census-rm-ddl-1.0-SNAPSHOT.jar casev2 uk.gov.ons.census.casesvc.model.entity
 java -jar target/census-rm-ddl-1.0-SNAPSHOT.jar actionv2 uk.gov.ons.census.action.model.entity
 java -jar target/census-rm-ddl-1.0-SNAPSHOT.jar uacqid uk.gov.ons.census.uacqid.model.entity
+java -jar target/census-rm-ddl-1.0-SNAPSHOT.jar exceptionmanager uk.gov.ons.census.exceptionmanager.model.entity

--- a/build_groundzero_ddl.sh
+++ b/build_groundzero_ddl.sh
@@ -33,7 +33,7 @@ fi
 if [ -z "$EXCEPTION_MANAGER_BRANCH" ]; then
   git clone git@github.com:ONSdigital/census-rm-exception-manager.git
 else
-  echo "Cloning UAC QID Service branch $EXCEPTION_MANAGER_BRANCH"
+  echo "Cloning Exception Manager branch $EXCEPTION_MANAGER_BRANCH"
   git clone --branch $EXCEPTION_MANAGER_BRANCH git@github.com:ONSdigital/census-rm-exception-manager.git
 fi
 

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,4 +4,4 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v2.3.0', current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v2.4.0', current_timestamp);

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1700, current_timestamp);
 INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v2.4.0', current_timestamp);

--- a/groundzero_ddl/destroy_schemas.sql
+++ b/groundzero_ddl/destroy_schemas.sql
@@ -2,5 +2,6 @@ begin transaction;
 drop schema IF EXISTS casev2 cascade;
 drop schema IF EXISTS actionv2 cascade;
 drop schema IF EXISTS uacqid cascade;
+drop schema IF EXISTS exceptionmanager cascade;
 drop schema IF EXISTS ddl_version cascade;
 commit transaction;

--- a/groundzero_ddl/exceptionmanager.sql
+++ b/groundzero_ddl/exceptionmanager.sql
@@ -1,0 +1,14 @@
+
+    create table quarantined_message (
+       id uuid not null,
+        content_type varchar(255),
+        error_reports jsonb,
+        headers jsonb,
+        message_hash varchar(255),
+        message_payload bytea,
+        queue varchar(255),
+        routing_key varchar(255),
+        service varchar(255),
+        skipped_timestamp timestamp with time zone,
+        primary key (id)
+    );

--- a/groundzero_ddl/rebuild_from_ground_zero.sh
+++ b/groundzero_ddl/rebuild_from_ground_zero.sh
@@ -3,7 +3,7 @@ cd groundzero_ddl
 PSQL_CONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/root/.postgresql/postgresql.key hostaddr=$DB_HOST user=rmuser password=password dbname=$DB_NAME"
 psql "$PSQL_CONNECT_WRITE_MODE" -f destroy_schemas.sql
 
-for SCHEMA_NAME in actionv2 casev2 uacqid ddl_version
+for SCHEMA_NAME in actionv2 casev2 uacqid exceptionmanager ddl_version
 do
   echo "begin transaction;" > header_footer_temp.txt
   echo "create schema if not exists $SCHEMA_NAME;" >> header_footer_temp.txt

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v2.3.0'
+current_version = 'v2.4.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/1700_create_exceptionmanager_schema.sql
+++ b/patches/1700_create_exceptionmanager_schema.sql
@@ -1,0 +1,16 @@
+create schema if not exists exceptionmanager;
+set schema exceptionmanager;
+create table quarantined_message (
+   id uuid not null,
+    content_type varchar(255),
+    error_reports jsonb,
+    headers jsonb,
+    message_hash varchar(255),
+    message_payload bytea,
+    queue varchar(255),
+    routing_key varchar(255),
+    service varchar(255),
+    skipped_timestamp timestamp with time zone,
+    primary key (id)
+);
+

--- a/patches/1700_create_exceptionmanager_schema.sql
+++ b/patches/1700_create_exceptionmanager_schema.sql
@@ -1,5 +1,5 @@
 create schema if not exists exceptionmanager;
-set schema exceptionmanager;
+set schema 'exceptionmanager';
 create table quarantined_message (
    id uuid not null,
     content_type varchar(255),

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.3.7.Final</version>
+      <version>5.4.15.Final</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
# Motivation and Context
For speed of development during the rehearsal, we didn't make the Exception Manager persistent. We now need to have the service backed by a persistent data store instead of using a Rabbit queue to save the quarantined messages.

# What has changed
Added persistence.

# How to test?
Publish a bad message onto a Rabbit queue. Quarantine the bad message. Check the `exceptionmanager` database.

# Links
Trello: https://trello.com/c/sYuR2Vgw