### PR TITLE
Migrate to new fulfilment_to_process table

### DIFF
--- a/groundzero_ddl/actionv2.sql
+++ b/groundzero_ddl/actionv2.sql
@@ -69,12 +69,24 @@
         primary key (id)
     );
 
-    create table fulfilment_to_send (
+    create table fulfilment_to_process (
        id  bigserial not null,
+        action_type varchar(255),
+        address_line1 varchar(255),
+        address_line2 varchar(255),
+        address_line3 varchar(255),
         batch_id uuid,
+        field_coordinator_id varchar(255),
+        field_officer_id varchar(255),
+        forename varchar(255),
         fulfilment_code varchar(255),
-        message_data jsonb not null,
+        organisation_name varchar(255),
+        postcode varchar(255),
         quantity int4,
+        surname varchar(255),
+        title varchar(255),
+        town_name varchar(255),
+        caze_case_ref int8,
         primary key (id)
     );
 
@@ -105,5 +117,10 @@ create index qid_idx on uac_qid_link (qid);
 
     alter table if exists case_to_process 
        add constraint FKfji3l4gnuwiha7gcdquu44fak 
+       foreign key (caze_case_ref) 
+       references cases;
+
+    alter table if exists fulfilment_to_process 
+       add constraint FKq3x3d2be44ac840lt6twonq8v 
        foreign key (caze_case_ref) 
        references cases;

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2000, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v2.7.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2100, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v3.0.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v2.7.0'
+current_version = 'v3.0.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/2100_fancy_new_fulfilment_to_send_table.sql
+++ b/patches/2100_fancy_new_fulfilment_to_send_table.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS actionv2.fulfilment_to_send;
 
 set schema 'actionv2';
 
-create table fulfilment_to_process (
+create table if not exists fulfilment_to_process (
    id  bigserial not null,
     action_type varchar(255),
     address_line1 varchar(255),

--- a/patches/2100_fancy_new_fulfilment_to_send_table.sql
+++ b/patches/2100_fancy_new_fulfilment_to_send_table.sql
@@ -1,0 +1,29 @@
+DROP TABLE IF EXISTS actionv2.fulfilment_to_send;
+
+set schema 'actionv2';
+
+create table fulfilment_to_process (
+   id  bigserial not null,
+    action_type varchar(255),
+    address_line1 varchar(255),
+    address_line2 varchar(255),
+    address_line3 varchar(255),
+    batch_id uuid,
+    field_coordinator_id varchar(255),
+    field_officer_id varchar(255),
+    forename varchar(255),
+    fulfilment_code varchar(255),
+    organisation_name varchar(255),
+    postcode varchar(255),
+    quantity int4,
+    surname varchar(255),
+    title varchar(255),
+    town_name varchar(255),
+    caze_case_ref int8,
+    primary key (id)
+);
+
+alter table if exists fulfilment_to_process
+   add constraint FKq3x3d2be44ac840lt6twonq8v
+   foreign key (caze_case_ref)
+   references cases;


### PR DESCRIPTION
# Motivation and Context
The refactored Action services use a new table called `fulfilment_to_process` and the old one is dead.

# What has changed
Create the table. Patch if necessary.

# Checklist
Reminder: Make sure to version tag this after the PR is merged
* [x] Updated patch number
* [x] Updated version_tag in `ddl_version.sql`
* [x] Updated current_version in `patch_database.py`

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/OyqQnLqX