### PR TITLE
Rename action_type column to fulfilment_type

### DIFF
--- a/groundzero_ddl/ACTION-ddl_version.sql
+++ b/groundzero_ddl/ACTION-ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (200, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.1.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (300, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.2.0', current_timestamp);

--- a/groundzero_ddl/actionv2.sql
+++ b/groundzero_ddl/actionv2.sql
@@ -73,7 +73,6 @@
 
     create table fulfilment_to_process (
        id  bigserial not null,
-        action_type varchar(255),
         address_line1 varchar(255),
         address_line2 varchar(255),
         address_line3 varchar(255),
@@ -82,6 +81,7 @@
         field_officer_id varchar(255),
         forename varchar(255),
         fulfilment_code varchar(255),
+        fulfilment_type varchar(255),
         organisation_name varchar(255),
         postcode varchar(255),
         quantity int4,

--- a/patch_database.py
+++ b/patch_database.py
@@ -12,7 +12,7 @@ PATCHES_DIRECTORY_ACTION = Path(__file__).parent.joinpath('patches/action')
 current_version = 'v4.2.0'
 
 # current_version_action should match the version in the ACTION-ddl_version.sql file
-current_version_action = 'v1.1.0'
+current_version_action = 'v1.2.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/action/300_rename_action_type_column_to_fulfilment_type.sql
+++ b/patches/action/300_rename_action_type_column_to_fulfilment_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE actionv2.fulfilment_to_process RENAME action_type TO fulfilment_type;


### PR DESCRIPTION
# Motivation and Context
Using the _action_ type for fulfillments was super confusing in the code, so I created a new enumeration for the non-actions (i.e. fulfillments) and the database should reflect that change.

# What has changed
Renamed `action_type` to `fulfilment_type` in the `fulfilment_to_process` table.

# Checklist
Reminder: Make you have run `build_groundzero_ddl.sh` and not manually edited the ground zero DDL.
* [x] Have run automated script, not made manual changes

Reminder: Make sure to version tag this after the PR is merged
* [x] Updated patch number
* [x] Updated version_tag in `ddl_version.sql`
* [x] Updated current_version in `patch_database.py`

# How to test?
Try it in your DB.

# Links
Trello: https://trello.com/c/J1Gr5PNq