### PR TITLE
Add index on postcode

### DIFF
--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -85,7 +85,7 @@ create index event_caze_case_id on event (caze_case_id);
 create index qid_idx on uac_qid_link (qid);
 create index uac_qid_caze_case_id on uac_qid_link (caze_case_id);
 
-    alter table if exists event
+    alter table if exists event 
        add constraint FKkrvohvnibf3k12ljhgiqrqicj 
        foreign key (caze_case_id) 
        references cases;

--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -77,6 +77,7 @@
     );
 create index cases_case_ref_idx on cases (case_ref);
 create index lsoa_idx on cases (lsoa);
+create index postcode_idx on cases (postcode);
 create index event_type_idx on event (event_type);
 create index rm_event_processed_idx on event (rm_event_processed);
 create index event_uac_qid_link_id on event (uac_qid_link_id);
@@ -84,7 +85,7 @@ create index event_caze_case_id on event (caze_case_id);
 create index qid_idx on uac_qid_link (qid);
 create index uac_qid_caze_case_id on uac_qid_link (caze_case_id);
 
-    alter table if exists event 
+    alter table if exists event
        add constraint FKkrvohvnibf3k12ljhgiqrqicj 
        foreign key (caze_case_id) 
        references cases;

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2500, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.2.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2600, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.3.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -9,7 +9,7 @@ PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches/main')
 PATCHES_DIRECTORY_ACTION = Path(__file__).parent.joinpath('patches/action')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v4.2.0'
+current_version = 'v4.3.0'
 
 # current_version_action should match the version in the ACTION-ddl_version.sql file
 current_version_action = 'v1.1.0'

--- a/patches/main/2600_add_index_on_postcode.sql
+++ b/patches/main/2600_add_index_on_postcode.sql
@@ -1,0 +1,1 @@
+create index postcode_idx on casev2.cases (postcode);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The first feature needed for ops-ui is to be able to search for cases via a postcode. This PR adds a index on the postcode column in the cases table

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added index on the postcode column

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run with the other branches on the ticket
- Try searching for cases on ops-ui
- Run the ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/qkkjvupd)
