### PR TITLE
Manually applied postcode search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,11 @@ Once you have run the the `build_groundzero_ddl.sh` script, you will be able to 
 ## Patching a database
 The script `patch_database.py` is used by RM to run database patches from a tagged release of this repository. This script is invoked from our pipelines and will run in a Kubernetes pod to apply any database patches from files in the tagged release version of this repository.
 
+## Manually applied indexes
+[manually_applied_indexes.sql]() Contains indexes we can't or don't want to create in the ground zero scripts. It can be manually run into the database after the main/largest sample load to keep ingest times as fast as possible.
+
+Indexes:
+* postcode_upper_no_space_idx - Index for case/space insensitive postcode search
+
 ## Releasing this repo
 When tagging a release of this repo you must update the version and and patch number in [ddl_version.sql](groundzero_ddl/ddl_version.sql) and update the current_version variable in [patch_database.py](patch_database.py)

--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -77,7 +77,6 @@
     );
 create index cases_case_ref_idx on cases (case_ref);
 create index lsoa_idx on cases (lsoa);
-create index postcode_idx on cases (postcode);
 create index event_type_idx on event (event_type);
 create index rm_event_processed_idx on event (rm_event_processed);
 create index event_uac_qid_link_id on event (uac_qid_link_id);

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.3.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2700, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.4.0', current_timestamp);

--- a/manually_applied_indexes.sql
+++ b/manually_applied_indexes.sql
@@ -1,0 +1,2 @@
+-- Index for case/space insensitive postcode search
+CREATE INDEX postcode_upper_no_space_idx ON casev2.cases (UPPER(REPLACE(postcode, ' ', '')));

--- a/patch_database.py
+++ b/patch_database.py
@@ -9,7 +9,7 @@ PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches/main')
 PATCHES_DIRECTORY_ACTION = Path(__file__).parent.joinpath('patches/action')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v4.3.0'
+current_version = 'v4.4.0'
 
 # current_version_action should match the version in the ACTION-ddl_version.sql file
 current_version_action = 'v1.2.0'

--- a/patches/main/2700_remove_index_on_postcode.sql
+++ b/patches/main/2700_remove_index_on_postcode.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS postcode_idx;


### PR DESCRIPTION

# Motivation and Context
The index on the postcode column alone did not aid the postcode search queries.

# What has changed
* Delete postcode index
* Add manually applied indexes script
* Add postcode search index to manual indexes
* Update README
# Checklist

Reminder: Make you have run `build_groundzero_ddl.sh` and not manually edited the ground zero DDL.
* [x] Have run automated script, not made manual changes

Reminder: Make sure to version tag this after the PR is merged
* [x] Updated patch number
* [x] Updated version_tag in `ddl_version.sql`
* [x] Updated current_version in `patch_database.py`

# How to test?
Check the scripts

# Links
https://trello.com/c/fg58euQh/1361-add-a-fancy-pants-index-on-postcode-column-to-speed-up-rops-query-time