### PR TITLE
fix rebuild script to use PASSWORD var or default to "password"

### DIFF
--- a/groundzero_ddl/rebuild_from_ground_zero.sh
+++ b/groundzero_ddl/rebuild_from_ground_zero.sh
@@ -1,7 +1,7 @@
 cd groundzero_ddl
 
-PSQL_CONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/root/.postgresql/postgresql.key hostaddr=$DB_HOST user=rmuser password=password dbname=$DB_NAME"
-PSQL_ACTIONCONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql-action/root.crt sslcert=/root/.postgresql-action/postgresql.crt sslkey=/root/.postgresql-action/postgresql.key hostaddr=$DB_HOST_ACTION user=rmuser password=password dbname=$DB_NAME"
+PSQL_CONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/root/.postgresql/postgresql.key hostaddr=$DB_HOST user=rmuser password=${PASSWORD:=password} dbname=$DB_NAME"
+PSQL_ACTIONCONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql-action/root.crt sslcert=/root/.postgresql-action/postgresql.crt sslkey=/root/.postgresql-action/postgresql.key hostaddr=$DB_HOST_ACTION user=rmuser password=${PASSWORD:=password} dbname=$DB_NAME"
 
 psql "$PSQL_CONNECT_WRITE_MODE" -f destroy_schemas.sql
 psql "$PSQL_ACTIONCONNECT_WRITE_MODE" -f ACTION-destroy_schemas.sql


### PR DESCRIPTION
# Motivation and Context
The rebuild_from_ground_zero.sh script is hardcoded to use "password", this makes it a bit of a pain when running it against non-dev envs

# What has changed
changed rebuild_from_ground_zero.sh so you can pass a "PASSWORD" var or it will default to using password like it did before

# How to test?
- run the ddl pod in your test env
- rebuild_from_ground_zero.sh and it should run fine
- change the db password to something else and run PASSWORD=<you new db password> rebuild_from_ground_zero.sh