### PR TITLE
Add new columns for Exception Manager rules

### DIFF
--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2800, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.5.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2900, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.6.0', current_timestamp);

--- a/groundzero_ddl/exceptionmanager.sql
+++ b/groundzero_ddl/exceptionmanager.sql
@@ -2,6 +2,10 @@
     create table auto_quarantine_rule (
        id uuid not null,
         expression varchar(255),
+        quarantine BOOLEAN DEFAULT false not null,
+        rule_expiry_date_time timestamp with time zone,
+        suppress_logging BOOLEAN DEFAULT false not null,
+        throw_away BOOLEAN DEFAULT false not null,
         primary key (id)
     );
 

--- a/patch_database.py
+++ b/patch_database.py
@@ -9,7 +9,7 @@ PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches/main')
 PATCHES_DIRECTORY_ACTION = Path(__file__).parent.joinpath('patches/action')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v4.5.0'
+current_version = 'v4.6.0'
 
 # current_version_action should match the version in the ACTION-ddl_version.sql file
 current_version_action = 'v1.2.0'

--- a/patches/main/2900_new_exception_rule_attributes.sql
+++ b/patches/main/2900_new_exception_rule_attributes.sql
@@ -1,0 +1,11 @@
+ALTER TABLE exceptionmanager.auto_quarantine_rule
+    ADD COLUMN IF NOT EXISTS quarantine BOOLEAN DEFAULT false not null;
+
+ALTER TABLE exceptionmanager.auto_quarantine_rule
+    ADD COLUMN IF NOT EXISTS suppress_logging BOOLEAN DEFAULT false not null;
+
+ALTER TABLE exceptionmanager.auto_quarantine_rule
+    ADD COLUMN IF NOT EXISTS throw_away BOOLEAN DEFAULT false not null;
+
+ALTER TABLE exceptionmanager.auto_quarantine_rule
+    ADD COLUMN IF NOT EXISTS rule_expiry_date_time timestamp with time zone;


### PR DESCRIPTION
# Motivation and Context
Sometimes, the 3 retries with a 1-second delay is inadequate, and we end up logging and raising an exception with the exception manager. This could be really annoying during the Census, because it will generate a lot of noise. When we've been war-gaming, we've seen that a flood of messages can cause exceptions which resolve themselves, due to locking contention, for example.

# What has changed
Implemented a configurable "minimum number of times to see an exception before we log it".

Implemented a filter on the admin API so that it only returns exceptions which have been seen a certain number of times.

ADDENDUM: I kinda went a bit mad and added more features. Can now "throw away" bad messages (silently skip, don't quarantine, don't log). Can suppress all logging (but not skip/quarantine) if logs are getting noisy. Also, added an expiry date for rules.

# How to test?
Create some exceptions. Only the ones which have been seen more than once should log, and the toolbox bad message wizard should also not see anything which has only been seen once.

# Links
Trello: https://trello.com/c/hP1iPanw