### PR TITLE
AddressTypeChange for CE Case ceActualResponses Defaulted to Zero

### DIFF
--- a/groundzero_ddl/ACTION-ddl_version.sql
+++ b/groundzero_ddl/ACTION-ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (300, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.2.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (400, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.0', current_timestamp);

--- a/groundzero_ddl/actionv2.sql
+++ b/groundzero_ddl/actionv2.sql
@@ -28,7 +28,7 @@
         address_type varchar(255),
         case_id uuid not null,
         case_type varchar(255),
-        ce_actual_responses int4,
+        ce_actual_responses int4 not null,
         ce_expected_capacity int4,
         collection_exercise_id uuid,
         created_date_time timestamp with time zone,

--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -11,7 +11,7 @@
         address_type varchar(255),
         case_ref int8,
         case_type varchar(255),
-        ce_actual_responses int4,
+        ce_actual_responses int4 not null,
         ce_expected_capacity int4,
         collection_exercise_id uuid,
         created_date_time timestamp with time zone,

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (2900, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.6.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (3000, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.7.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -12,7 +12,7 @@ PATCHES_DIRECTORY_ACTION = Path(__file__).parent.joinpath('patches/action')
 current_version = 'v4.7.0'
 
 # current_version_action should match the version in the ACTION-ddl_version.sql file
-current_version_action = 'v1.2.0'
+current_version_action = 'v1.3.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patch_database.py
+++ b/patch_database.py
@@ -9,7 +9,7 @@ PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches/main')
 PATCHES_DIRECTORY_ACTION = Path(__file__).parent.joinpath('patches/action')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v4.6.0'
+current_version = 'v4.7.0'
 
 # current_version_action should match the version in the ACTION-ddl_version.sql file
 current_version_action = 'v1.2.0'

--- a/patches/action/400_alter_ce_actual_responses_to_be_not_null.sql
+++ b/patches/action/400_alter_ce_actual_responses_to_be_not_null.sql
@@ -1,0 +1,4 @@
+UPDATE actionv2.cases SET ce_actual_responses = 0 WHERE ce_actual_responses IS NULL;
+
+ALTER TABLE actionv2.cases ALTER COLUMN ce_actual_responses SET NOT NULL;
+

--- a/patches/main/3000_alter_ce_actual_responses_to_be_not_null.sql
+++ b/patches/main/3000_alter_ce_actual_responses_to_be_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE casev2.cases ALTER COLUMN ce_actual_responses SET NOT NULL;

--- a/patches/main/3000_alter_ce_actual_responses_to_be_not_null.sql
+++ b/patches/main/3000_alter_ce_actual_responses_to_be_not_null.sql
@@ -1,1 +1,2 @@
-ALTER TABLE casev2.cases ALTER COLUMN ce_actual_responses SET NOT NULL;
+UPDATE casev2.cases SET ce_actual_responses = 0 WHERE ce_actual_responses IS NULL;
+

--- a/patches/main/3000_alter_ce_actual_responses_to_be_not_null.sql
+++ b/patches/main/3000_alter_ce_actual_responses_to_be_not_null.sql
@@ -1,2 +1,4 @@
 UPDATE casev2.cases SET ce_actual_responses = 0 WHERE ce_actual_responses IS NULL;
 
+ALTER TABLE casev2.cases ALTER COLUMN ce_actual_responses SET NOT NULL;
+


### PR DESCRIPTION
# Motivation and Context
When an AddressTypeChange event occurs where the new address is a CE Case, the ceActualResponses is null rather than 0 

# What has changed
Set column to be not null

# How to test?
Test locally 

# Links
https://trello.com/c/DUgevj8y