### PR TITLE
1874 Add index to UPRN field in cases table

### DIFF
--- a/groundzero_ddl/casev2.sql
+++ b/groundzero_ddl/casev2.sql
@@ -78,6 +78,7 @@
     );
 create index cases_case_ref_idx on cases (case_ref);
 create index lsoa_idx on cases (lsoa);
+create index uprn_idx on cases (uprn);
 create index event_type_idx on event (event_type);
 create index rm_event_processed_idx on event (rm_event_processed);
 create index event_uac_qid_link_id on event (uac_qid_link_id);

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (3100, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.8.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (3200, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v4.9.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -9,7 +9,7 @@ PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches/main')
 PATCHES_DIRECTORY_ACTION = Path(__file__).parent.joinpath('patches/action')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v4.8.0'
+current_version = 'v4.9.0'
 
 # current_version_action should match the version in the ACTION-ddl_version.sql file
 current_version_action = 'v1.3.0'

--- a/patches/main/3200_add_index_on_case_uprn.sql
+++ b/patches/main/3200_add_index_on_case_uprn.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS uprn_idx ON casev2.cases (uprn);


### PR DESCRIPTION
# Motivation and Context
We need speedy look ups on UPRN for case API, this PR adds an index to facilitate.

# What has changed
* Regenerate groundzero DDL with uprn index
* Add patch script to create index

# Checklist
Reminder: Make you have run `build_groundzero_ddl.sh` and not manually edited the ground zero DDL.
* [x] Have run automated script, not made manual changes

Reminder: Make sure to version tag this after the PR is merged
* [x] Updated patch number
* [x] Updated version_tag in `ddl_version.sql`
* [x] Updated current_version in `patch_database.py`

# How to test?
Check the patch SQL runs, regenerate the DDL off the linked case processor branch to verify it doesn't change. 

# Links
https://trello.com/c/XWfypxu8/1874-add-indexes-to-uprn-field-in-cases-db-table-5
https://github.com/ONSdigital/census-rm-case-api/pull/104
https://github.com/ONSdigital/census-rm-case-processor/pull/227