### PR TITLE
Add RM support permission definitions

### DIFF
--- a/permissions/RM-Support-Action-Permissions.sql
+++ b/permissions/RM-Support-Action-Permissions.sql
@@ -1,0 +1,17 @@
+CREATE ROLE rm_support;
+
+GRANT CONNECT ON DATABASE rm TO rm_support;
+
+GRANT USAGE ON SCHEMA actionv2 TO rm_support;
+GRANT USAGE ON SCHEMA ddl_version TO rm_support;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA actionv2 TO rm_support;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA actionv2 TO rm_support;
+GRANT SELECT ON ALL TABLES IN SCHEMA ddl_version TO rm_support;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA ddl_version TO rm_support;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA actionv2 GRANT SELECT ON TABLES TO rm_support;
+ALTER DEFAULT PRIVILEGES IN SCHEMA ddl_version GRANT SELECT ON TABLES TO rm_support;
+
+-- For run-booked insertion and amendments to action rules
+GRANT SELECT, UPDATE, INSERT, DELETE ON actionv2.action_rule TO rm_support;

--- a/permissions/RM-Support-Permissions.sql
+++ b/permissions/RM-Support-Permissions.sql
@@ -1,0 +1,25 @@
+CREATE ROLE rm_support;
+
+GRANT CONNECT ON DATABASE rm TO rm_support;
+
+GRANT USAGE ON SCHEMA casev2 TO rm_support;
+GRANT USAGE ON SCHEMA exceptionmanager TO rm_support;
+GRANT USAGE ON SCHEMA uacqid TO rm_support;
+GRANT USAGE ON SCHEMA ddl_version TO rm_support;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA casev2 TO rm_support;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA casev2 TO rm_support;
+GRANT SELECT ON ALL TABLES IN SCHEMA exceptionmanager TO rm_support;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA exceptionmanager TO rm_support;
+GRANT SELECT ON ALL TABLES IN SCHEMA uacqid TO rm_support;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA uacqid TO rm_support;
+GRANT SELECT ON ALL TABLES IN SCHEMA ddl_version TO rm_support;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA ddl_version TO rm_support;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA casev2 GRANT SELECT ON TABLES TO rm_support;
+ALTER DEFAULT PRIVILEGES IN SCHEMA exceptionmanager GRANT SELECT ON TABLES TO rm_support;
+ALTER DEFAULT PRIVILEGES IN SCHEMA uacqid GRANT SELECT ON TABLES TO rm_support;
+ALTER DEFAULT PRIVILEGES IN SCHEMA ddl_version GRANT SELECT ON TABLES TO rm_support;
+
+-- For creating/editing/deleting auto quarantine rules
+GRANT SELECT, UPDATE, INSERT, DELETE ON exceptionmanager.auto_quarantine_rule TO rm_support;


### PR DESCRIPTION
# Motivation and Context
We need a permission level with minimum required for daily/expected run booked tasks. These are copies of the read access permissions but with a couple of specific write/edit/delete perms where required.

# What has changed
* Add main/action support permission definitions 

# Checklist
Reminder: Make you have run `build_groundzero_ddl.sh` and not manually edited the ground zero DDL.
* [ ] Have run automated script, not made manual changes

Reminder: Make sure to version tag this after the PR is merged
* [ ] Updated patch number
* [ ] Updated version_tag in `ddl_version.sql`
* [ ] Updated current_version in `patch_database.py`

# How to test?
Run the scripts into your dev environment, grant the role to a user and check you can read/edit tables appropriately.

# Links
https://trello.com/c/escpI4sW/2018-create-support-db-permission-roles